### PR TITLE
Move away from deprecated sendAction function

### DIFF
--- a/addon/components/mobiledoc-editor/component.js
+++ b/addon/components/mobiledoc-editor/component.js
@@ -289,7 +289,7 @@ export default Component.extend({
     editor.destroy();
   },
 
-  'on-change': () => {},
+  'on-change'() {},
 
   postDidChange(editor) {
     let serializeVersion = this.get('serializeVersion');
@@ -326,13 +326,13 @@ export default Component.extend({
 
   },
 
-  'will-create-editor': () => {},
+  'will-create-editor'() {},
 
   willCreateEditor() {
     this['will-create-editor']();
   },
 
-  'did-create-editor': () => {},
+  'did-create-editor'() {},
 
   didCreateEditor(editor) {
     this['did-create-editor'](editor);

--- a/addon/components/mobiledoc-editor/component.js
+++ b/addon/components/mobiledoc-editor/component.js
@@ -289,13 +289,13 @@ export default Component.extend({
     editor.destroy();
   },
 
+  'on-change': () => {},
+
   postDidChange(editor) {
     let serializeVersion = this.get('serializeVersion');
     let updatedMobileDoc = editor.serialize(serializeVersion);
-    if(this['on-change']) {
-      this._mobiledoc = updatedMobileDoc;
-      this['on-change'](updatedMobileDoc);
-    }
+    this._mobiledoc = updatedMobileDoc;
+    this['on-change'](updatedMobileDoc);
   },
 
   inputModeDidChange(editor) {
@@ -326,12 +326,16 @@ export default Component.extend({
 
   },
 
+  'will-create-editor': () => {},
+
   willCreateEditor() {
-    this.sendAction(WILL_CREATE_EDITOR_ACTION); // eslint-disable-line ember/closure-actions
+    this['will-create-editor']();
   },
 
+  'did-create-editor': () => {},
+
   didCreateEditor(editor) {
-    this.sendAction(DID_CREATE_EDITOR_ACTION, editor); // eslint-disable-line ember/closure-actions
+    this['did-create-editor'](editor);
   },
 
   _addAtom(atomName, text, payload) {


### PR DESCRIPTION
[copied PR from upstream]

This closes #160. I followed the deprecation guidelines here:
https://deprecations-app-prod.herokuapp.com/deprecations/v3.x/#toc_ember-component-send-action

However, there are various ways this could be accomplished,
so I’ll be asking for feedback in my PR.